### PR TITLE
Run tests on Ruby 2.0 and remove deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: ruby
 rvm:
   - 1.8.7
   - 1.9.3
+  - 2.0.0
 script: "script/test_all 2>&1"

--- a/lib/rgl/transitivity.rb
+++ b/lib/rgl/transitivity.rb
@@ -1,5 +1,3 @@
-require 'enumerator'
-
 require 'rgl/base'
 require 'rgl/adjacency'
 require 'rgl/condensation'
@@ -120,7 +118,7 @@ module RGL
           # Only add the edge v -> w if there is no other edge v -> x such that
           # w is reachable from x. Make sure to completely skip the case where
           # x == w.
-          unless Enumerator.new(cg, :each_adjacent, v).any? { |x| x != w && paths_from[x].include?(w) }
+          unless cg.to_enum(:each_adjacent, v).any? { |x| x != w && paths_from[x].include?(w) }
             tr_cg.add_edge(v, w)
 
             # For each vertex v, track all nodes reachable from v by adding node
@@ -159,7 +157,7 @@ module RGL
 
         # Choose a single edge between the members of two different strongly
         # connected component to add to the graph.
-        edges = Enumerator.new(self, :each_edge)
+        edges = self.to_enum(:each_edge)
         tr_cg.each_adjacent(scc) do |scc2|
           g.add_edge(
               *edges.find do |v, w|


### PR DESCRIPTION
I've removed two warnings related to the deprecation of `Enumerator.new` in favor of `Object#to_enum` in Ruby 2.0, and enabled this version in `travis.yml`.

All tests are green running `script/test_all` for me in Ruby versions 1.8.7-p371, 1.9.3-p392, and 2.0.0-p0. Let me know if it's all good.
