### PR TITLE
Implement Graph#bipartite_sets.

### DIFF
--- a/lib/rgl/bipartite.rb
+++ b/lib/rgl/bipartite.rb
@@ -1,0 +1,87 @@
+require 'rgl/base'
+require 'rgl/traversal'
+
+module RGL
+
+  module Graph
+
+    # Separates graph's vertices into two disjoint sets so that every edge of the graph connects vertices from different
+    # sets. If it's possible, the graph is bipartite.
+    #
+    # Returns an array of two disjoint vertices sets (represented as arrays) if the graph is bipartite. Otherwise,
+    # returns nil.
+    #
+    def bipartite_sets
+      raise NotUndirectedError.new('bipartite sets can only be found for an undirected graph') if directed?
+
+      bfs = BipartiteBFSIterator.new(self)
+
+      # if necessary, we start BFS from each vertex to make sure
+      # that all connected components of the graph are processed
+      each_vertex do |u|
+        next if bfs.finished_vertex?(u)
+
+        bfs.reset_start(u)
+        bfs.move_forward_until { @found_odd_cycle }
+
+        return if bfs.found_odd_cycle
+      end
+
+      bfs.bipartite_sets_map.inject([[], []]) do |sets, (vertex, set)|
+        sets[set] << vertex
+        sets
+      end
+    end
+
+    # Returns true if the graph is bipartite. Otherwise returns false.
+    #
+    def bipartite?
+      !bipartite_sets.nil?
+    end
+
+  end # module Graph
+
+  class BipartiteBFSIterator < BFSIterator
+
+    attr_reader :bipartite_sets_map, :found_odd_cycle
+
+    def reset
+      super
+
+      @bipartite_sets_map = {}
+      @found_odd_cycle = false
+    end
+
+    def set_to_begin
+      super
+
+      @bipartite_sets_map[@start_vertex] = 0
+    end
+
+    def reset_start(new_start)
+      @start_vertex = new_start
+      set_to_begin
+    end
+
+    def handle_tree_edge(u, v)
+      @bipartite_sets_map[v] = (@bipartite_sets_map[u] + 1) % 2 unless u.nil?  # put v into the other set
+    end
+
+    def handle_back_edge(u, v)
+      verify_odd_cycle(u, v)
+    end
+
+    def handle_forward_edge(u, v)
+      verify_odd_cycle(u, v)
+    end
+
+    private
+
+    def verify_odd_cycle(u, v)
+      u_set = @bipartite_sets_map[u]
+      @found_odd_cycle = true if u_set && u_set == @bipartite_sets_map[v]
+    end
+
+  end # class BipartiteBFSIterator
+
+end # module RGL

--- a/test/bipartite_test.rb
+++ b/test/bipartite_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+require 'rgl/bipartite'
+require 'rgl/adjacency'
+
+include RGL
+
+class TestBipartite < Test::Unit::TestCase
+
+  def test_bipartite_sets
+    assert_equal([[1, 2, 3], [4, 5, 6]], bipartite_sets(AdjacencyGraph[1,5, 1,6, 2,4, 2,5, 3,4, 3,5, 3,6]))
+  end
+
+  def test_bipartite_sets_for_non_bipartite_graph
+    assert_equal(nil, bipartite_sets(AdjacencyGraph[1,4, 1,5, 2,3, 2,4, 2,5, 3,5]))
+  end
+
+  def test_bipartite_sets_for_directed_graph
+    assert_raise(NotUndirectedError, 'bipartite sets can only be found for an undirected graph') do
+      DirectedAdjacencyGraph.new.bipartite_sets
+    end
+  end
+
+  def test_bipartite_sets_for_bipartite_disconnected_graph
+    assert_equal([[1, 3], [2, 4]], bipartite_sets(AdjacencyGraph[1,2, 3,4]))
+  end
+
+  def test_bipartite_sets_for_non_bipartite_disconnected_graph
+    assert_equal(nil, bipartite_sets(AdjacencyGraph[1,2, 3,4, 4,5, 5,3]))
+  end
+
+  def test_bipartite
+    assert(AdjacencyGraph[1,2, 2,3].bipartite?)
+  end
+
+  def test_not_bipartite
+    assert(!AdjacencyGraph[1,2, 2,3, 3,1].bipartite?)
+  end
+
+  private
+
+  def bipartite_sets(graph)
+    sets = graph.bipartite_sets
+    sets && sets.map { |set| set.sort }.sort
+  end
+
+end


### PR DESCRIPTION
Here's an implementation of an algorithm that splits vertices of a bipartite graph into two sets. It can also be used to check if a graph is bipartite or not.

Before releasing a new version of RGL I'd like to implement one more algorithm – Khun's algorithm for finding a maximum matching in a bipartite graph. I'm not quite sure when I'll have time to work on it, but I hope I'll get to it soon.
