### PR TITLE
Show duplicate labels in DOT visualisations

### DIFF
--- a/lib/rgl/dot.rb
+++ b/lib/rgl/dot.rb
@@ -23,18 +23,17 @@ module RGL
       edge_class     = directed? ? DOT::DirectedEdge : DOT::Edge
 
       each_vertex do |v|
-        name = v.to_s
         graph << DOT::Node.new(
-            'name'     => name,
+            'name'     => v.object_id,
             'fontsize' => fontsize,
-            'label'    => name
+            'label'    => v.to_s
         )
       end
 
       each_edge do |u, v|
         graph << edge_class.new(
-            'from'     => u.to_s,
-            'to'       => v.to_s,
+            'from'     => u.object_id,
+            'to'       => v.object_id,
             'fontsize' => fontsize
         )
       end

--- a/test/dot_test.rb
+++ b/test/dot_test.rb
@@ -13,10 +13,15 @@ class TestDot < Test::Unit::TestCase
     graph = RGL::DirectedAdjacencyGraph[1, 2]
     dot   = graph.to_dot_graph.to_s
 
+    first_vertex_id = 1.object_id
+    second_vertex_id = 2.object_id
+    
     assert_match(dot, /\{[^}]*\}/) # {...}
-    assert_match(dot, /1\s*\[/)    # node 1
-    assert_match(dot, /2\s*\[/)    # node 2
-    assert_match(dot, /1\s*->\s*2/) # edge
+    assert_match(dot, /#{first_vertex_id}\s*\[/)  # node 1
+    assert_match(dot, /label\s*=\s*1/)            # node 1 label
+    assert_match(dot, /#{second_vertex_id}\s*\[/) # node 2
+    assert_match(dot, /label\s*=\s*2/)            # node 2 label
+    assert_match(dot, /#{first_vertex_id}\s*->\s*#{second_vertex_id}/) # edge
   end
 
   def test_to_dot_graph


### PR DESCRIPTION
This patch is intended to fix issue #15.

DOT seems to treat the names of vertices as unique, and does not show more than one vertex with the same name. So, I suggest that `object_id` is used to name vertices in the DOT visualisation, rather than `to_s`.