### PR TITLE
Switched to a different heap implementation.

### DIFF
--- a/lib/rgl/bellman_ford.rb
+++ b/lib/rgl/bellman_ford.rb
@@ -2,8 +2,7 @@ require 'rgl/dijkstra_visitor'
 require 'rgl/edge_properties_map'
 require 'rgl/path_builder'
 
-require 'delegate'
-require 'algorithms'
+require 'lazy_priority_queue'
 
 module RGL
 

--- a/rgl.gemspec
+++ b/rgl.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   #### Dependencies and requirements.
 
   s.add_dependency 'stream',     '~> 0.5.0'
-  s.add_dependency 'algorithms', '~> 0.6.1'
+  s.add_dependency 'lazy_priority_queue', '~> 0.1.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'yard'


### PR DESCRIPTION
I replaced kanwei/algorithms' priority queue which was causing dijkstra_shortest_path to fail (fixes #24).

The [proposed implementation](https://github.com/matiasbattocchia/lazy_priority_queue) runs ~2 times faster, has simpler API (supports decrease_key operation) and does not pull unnecessary code (it is just a priority queue).