### PR TITLE
drop 1.9.3 add newer jruby and rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,17 @@ branches:
   only:
     - master
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.6
-  - 2.2.2
-  - jruby-1.7.19
-  - jruby-9.0.0.0.rc2
+  - 2.2.4
+  - 2.3.0
+  - ruby-head
+  - jruby-1.7.22
+  - jruby-9.0.4.0
+  - jruby-head
+  - rbx-2.5.8
+matrix:
+  allow_failures:
+      - rvm: ruby-head
+      - rvm: jruby-head
 script: "COVERAGE=true script/test_all 2>&1"


### PR DESCRIPTION
Since 1.9.3 is EOLed and fails on travis, I think it makes sense to drop it, unless there's a need to continue support. I also added 2.3, the latest and head so that there is coverage for the latest ruby stuff. I also added allowed failures on head, as that's a moving target.