### PR TITLE
Allow edge + vertex options to be passed to #write_to_graphic_file

### DIFF
--- a/lib/rgl/dot.rb
+++ b/lib/rgl/dot.rb
@@ -42,7 +42,9 @@ module RGL
           'fontsize' => fontsize,
           'label'    => vertex_label(v)
         }
-        graph << DOT::Node.new(default_vertex_options.merge!(vertex_options))
+        each_vertex_options = default_vertex_options.merge(vertex_options)
+        vertex_options.each{|option, val| each_vertex_options[option] = val.call(u, v) if val.is_a?(Proc)}
+        graph << DOT::Node.new(each_vertex_options)
       end
 
       each_edge do |u, v|
@@ -51,7 +53,9 @@ module RGL
           'to'       => vertex_id(v),
           'fontsize' => fontsize
         }
-        graph << edge_class.new(default_edge_options.merge!(edge_options))
+        each_edge_options = default_edge_options.merge(edge_options)
+        edge_options.each{|option, val| each_edge_options[option] = val.call(u, v) if val.is_a?(Proc)}
+        graph << edge_class.new(each_edge_options)
       end
 
       graph

--- a/lib/rgl/dot.rb
+++ b/lib/rgl/dot.rb
@@ -43,7 +43,7 @@ module RGL
           'label'    => vertex_label(v)
         }
         each_vertex_options = default_vertex_options.merge(vertex_options)
-        vertex_options.each{|option, val| each_vertex_options[option] = val.call(u, v) if val.is_a?(Proc)}
+        vertex_options.each{|option, val| each_vertex_options[option] = val.call(v) if val.is_a?(Proc)}
         graph << DOT::Node.new(each_vertex_options)
       end
 

--- a/lib/rgl/dot.rb
+++ b/lib/rgl/dot.rb
@@ -33,21 +33,25 @@ module RGL
       fontsize       = params['fontsize'] ? params['fontsize'] : '8'
       graph          = (directed? ? DOT::Digraph : DOT::Graph).new(params)
       edge_class     = directed? ? DOT::DirectedEdge : DOT::Edge
+      vertex_options = params['vertex'] || {}
+      edge_options   = params['edge'] || {}
 
       each_vertex do |v|
-        graph << DOT::Node.new(
-            'name'     => vertex_id(v),
-            'fontsize' => fontsize,
-            'label'    => vertex_label(v)
-        )
+        default_vertex_options =  {
+          'name'     => vertex_id(v),
+          'fontsize' => fontsize,
+          'label'    => vertex_label(v)
+        }
+        graph << DOT::Node.new(default_vertex_options.merge!(vertex_options))
       end
 
       each_edge do |u, v|
-        graph << edge_class.new(
-            'from'     => vertex_id(u),
-            'to'       => vertex_id(v),
-            'fontsize' => fontsize
-        )
+        default_edge_options = {
+          'from'     => vertex_id(u),
+          'to'       => vertex_id(v),
+          'fontsize' => fontsize
+        }
+        graph << edge_class.new(default_edge_options.merge!(edge_options))
       end
 
       graph
@@ -75,12 +79,12 @@ module RGL
     # Use dot[http://www.graphviz.org] to create a graphical representation of
     # the graph. Returns the filename of the graphics file.
     #
-    def write_to_graphic_file(fmt='png', dotfile="graph")
+    def write_to_graphic_file(fmt='png', dotfile="graph", options={})
       src = dotfile + ".dot"
       dot = dotfile + "." + fmt
 
       File.open(src, 'w') do |f|
-        f << self.to_dot_graph.to_s << "\n"
+        f << self.to_dot_graph(options).to_s << "\n"
       end
 
       unless system("dot -T#{fmt} #{src} -o #{dot}")

--- a/test/dot_test.rb
+++ b/test/dot_test.rb
@@ -29,6 +29,28 @@ class TestDot < Test::Unit::TestCase
     end
   end
 
+  def test_to_dot_digraph_with_options
+      graph = RGL::DirectedAdjacencyGraph["a", "b"]
+
+    begin
+      dot_options = {'edge' => {'color' => 'red'}}
+      dot   = graph.to_dot_graph(dot_options).to_s
+
+      first_vertex_id = "a"
+      second_vertex_id = "b"
+
+      assert_match(dot, /\{[^}]*\}/) # {...}
+      assert_match(dot, /#{first_vertex_id}\s*\[/)  # node 1
+      assert_match(dot, /label\s*=\s*a/)            # node 1 label
+      assert_match(dot, /#{second_vertex_id}\s*\[/) # node 2
+      assert_match(dot, /label\s*=\s*b/)            # node 2 label
+      assert_match(dot, /#{first_vertex_id}\s*->\s*#{second_vertex_id}/) # edge
+      assert_match(dot, /color\s*=\s*red/)
+    rescue
+      puts "Graphviz not installed?"
+    end
+  end
+
   def test_to_dot_graph
     graph = RGL::AdjacencyGraph["a", "b"]
     def graph.vertex_label(v)

--- a/test/dot_test.rb
+++ b/test/dot_test.rb
@@ -33,19 +33,17 @@ class TestDot < Test::Unit::TestCase
       graph = RGL::DirectedAdjacencyGraph["a", "b"]
 
     begin
-      dot_options = {'edge' => {'color' => 'red'}}
-      dot   = graph.to_dot_graph(dot_options).to_s
+      edge_labels = {}
+      graph.each_edge do |b, e|
+        key              = "#{b}-#{e}"
+        edge_labels[key] = "#{b} to #{e}"
+      end
+      label_setting = Proc.new{|b, e| edge_labels["#{b}-#{e}"]}
+      dot_options   = {'edge' => {'color' => 'red', 'label' => label_setting}}
+      dot           = graph.to_dot_graph(dot_options).to_s
 
-      first_vertex_id = "a"
-      second_vertex_id = "b"
-
-      assert_match(dot, /\{[^}]*\}/) # {...}
-      assert_match(dot, /#{first_vertex_id}\s*\[/)  # node 1
-      assert_match(dot, /label\s*=\s*a/)            # node 1 label
-      assert_match(dot, /#{second_vertex_id}\s*\[/) # node 2
-      assert_match(dot, /label\s*=\s*b/)            # node 2 label
-      assert_match(dot, /#{first_vertex_id}\s*->\s*#{second_vertex_id}/) # edge
       assert_match(dot, /color\s*=\s*red/)
+      assert_match(dot, /a to b/)
     rescue
       puts "Graphviz not installed?"
     end

--- a/test/dot_test.rb
+++ b/test/dot_test.rb
@@ -38,12 +38,22 @@ class TestDot < Test::Unit::TestCase
         key              = "#{b}-#{e}"
         edge_labels[key] = "#{b} to #{e}"
       end
-      label_setting = Proc.new{|b, e| edge_labels["#{b}-#{e}"]}
-      dot_options   = {'edge' => {'color' => 'red', 'label' => label_setting}}
-      dot           = graph.to_dot_graph(dot_options).to_s
+      
+      vertex_fontcolors = {
+        'a' => 'green',
+        'b' => 'blue'
+      }
+      vertex_fontcolor_setting = Proc.new{|v| vertex_fontcolors[v]}
+      vertex_settings          = {'fontcolor' => vertex_fontcolor_setting, 'fontsize' => 12}
+      
+      edge_label_setting = Proc.new{|b, e| edge_labels["#{b}-#{e}"]}
+      edge_settings      = {'color' => 'red', 'label' => edge_label_setting}
+      dot_options        = {'edge' => edge_settings,'vertex' => vertex_settings}
+      dot                = graph.to_dot_graph(dot_options).to_s
 
-      assert_match(dot, /color\s*=\s*red/)
-      assert_match(dot, /a to b/)
+      assert_match(dot, /a \[\n\s*fontcolor = green,\n\s*fontsize = 12,\n\s*label = a\n\s*/)
+      assert_match(dot, /b \[\n\s*fontcolor = blue,\n\s*fontsize = 12,\n\s*label = a\n\s*/)
+      assert_match(dot, /a -> b \[\n\s*color = red,\n\s*fontsize = 8,\n\s*label = \"a to b\"\n/)
     rescue
       puts "Graphviz not installed?"
     end

--- a/test/dot_test.rb
+++ b/test/dot_test.rb
@@ -39,10 +39,7 @@ class TestDot < Test::Unit::TestCase
         edge_labels[key] = "#{b} to #{e}"
       end
       
-      vertex_fontcolors = {
-        'a' => 'green',
-        'b' => 'blue'
-      }
+      vertex_fontcolors = {'a' => 'green', 'b' => 'blue'}
       vertex_fontcolor_setting = Proc.new{|v| vertex_fontcolors[v]}
       vertex_settings          = {'fontcolor' => vertex_fontcolor_setting, 'fontsize' => 12}
       
@@ -52,7 +49,7 @@ class TestDot < Test::Unit::TestCase
       dot                = graph.to_dot_graph(dot_options).to_s
 
       assert_match(dot, /a \[\n\s*fontcolor = green,\n\s*fontsize = 12,\n\s*label = a\n\s*/)
-      assert_match(dot, /b \[\n\s*fontcolor = blue,\n\s*fontsize = 12,\n\s*label = a\n\s*/)
+      assert_match(dot, /b \[\n\s*fontcolor = blue,\n\s*fontsize = 12,\n\s*label = b\n\s*/)
       assert_match(dot, /a -> b \[\n\s*color = red,\n\s*fontsize = 8,\n\s*label = \"a to b\"\n/)
     rescue
       puts "Graphviz not installed?"


### PR DESCRIPTION
I was using this library, and I thought it would be nice to be able to pass additional edge and vertex options into the `write_to_graphic_file` method -- for instance, to add a label for each edge.

The idea is that the original default options get passed in, as well as any additional ones under `params['edge']` or `params['vertex']`. If the setting comes in the form of a `Proc`, then the proc is called on each edge pair or vertex. Otherwise, the setting will apply to all edges and all vertices.

Happy to add tests, or do some additional work to get this in. 

**Example:**

```ruby
graph = RGL::DirectedAdjacencyGraph["a", "b", "b", "c"]

# Edge Settings
edge_labels = {}
graph.each_edge do |b, e|
  key              = "#{b}-#{e}"
  edge_labels[key] = "#{b} to #{e}"
end
edge_label_setting = Proc.new{|b, e| edge_labels["#{b}-#{e}"]}
edge_colors = {"a-b" => "red", "b-c" => "purple"}
edge_color_setting = Proc.new{|b, e| edge_colors["#{b}-#{e}"]}
edge_settings  = {'color' => edge_color_setting, 'label' => edge_label_setting, 'fontsize' => 15}

# Vertex Settings
vertex_font_colors = {"a" => "blue", "b" => "green", "c" => "purple"}
vertex_font_color_setting = Proc.new{|b| vertex_font_colors[b]}
vertex_settings = {'fontcolor' => vertex_font_color_setting, 'fontsize' => 10}

# Options
dot_options = {'edge' => edge_settings, 'vertex' => vertex_settings}

graph.write_to_graphic_file('png', 'graph', dot_options)
```
![graph](https://user-images.githubusercontent.com/4339729/52131954-242e7c00-260c-11e9-852f-5a54a6731101.png)


