### PR TITLE
Add explicit license to gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ rvm:
   - 2.4
   - 2.5
   - ruby-head
-  - jruby
+  - jruby-9.1.9.0
   - jruby-head
 
 before_install:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,15 @@
-2016-05 Release 0.5.3
+2019-01 Release 0.5.4
+
+Lia Skalkos
+ * Enable options to be passed to #write_to_graphic_file (4ca972). For details see PR #41
+Horst Duchene
+ * Fix travis-ci errors
+ * Add new ruby versions
+ * Fix gemspec errors
+ * Fix lint warnings
+ * Use version stream 0.5.2
+
+2017-04 Release 0.5.3
 
 Horst Duchene
  * Issue #38: Add error handling or dot functions. (719e38, 5a3423)

--- a/README.md
+++ b/README.md
@@ -254,5 +254,5 @@ See also http://github.com/monora/rgl/contributors.
 ## Copying
 
 RGL is Copyright (c) 2002,2004,2005,2008,2013,2015,2019 by Horst Duchene. It is
-free software, and may be redistributed under the terms specified in the
+free software, and may be redistributed under the license and terms specified in the
 README file of the Ruby distribution.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ The result:
 
 ![Example](https://github.com/monora/rgl/raw/master/images/example.jpg)
 
+You can control the graph layout by passing layout parameters to `write_to_graphic_file`. See
+`TestDot::test_to_dot_digraph_with_options` for an example using a feature implemented by Lia
+Skalkos (see [PR #41](https://github.com/monora/rgl/pull/41)).
+
     irb> dg.directed?
     true
     irb> dg.vertices
@@ -249,6 +253,6 @@ See also http://github.com/monora/rgl/contributors.
 
 ## Copying
 
-RGL is Copyright (c) 2002,2004,2005,2008,2013,2015 by Horst Duchene. It is
+RGL is Copyright (c) 2002,2004,2005,2008,2013,2015,2019 by Horst Duchene. It is
 free software, and may be redistributed under the terms specified in the
 README file of the Ruby distribution.

--- a/rgl.gemspec
+++ b/rgl.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
   s.version = RGL_VERSION
   s.summary = "Ruby Graph Library"
   s.description = "RGL is a framework for graph data structures and algorithms"
+  s.license = "ruby"
 
   #### Dependencies and requirements.
 


### PR DESCRIPTION
This adds the license to the gemspec so the gem passes checkers like [LicenseFinder](https://github.com/pivotal/LicenseFinder).