### PR TITLE
Test against Ruby 2.6 and 2.7 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
+  - 2.7
   - ruby-head
   - jruby
   - jruby-head


### PR DESCRIPTION
Ruby 2.6 has been released in 2018, and Ruby 2.7 has been released in 2019. Ruby 3.0 release is coming soon within a couple of weeks. Let's test against 2.6 and 2.7 first.

(I noticed you're trying to migrate to GitHub Actions at https://github.com/monora/rgl/pull/49, but I think that that can be done later.)