### PR TITLE
Test against Ruby 3.0 and 3.1 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
+  - 3.1
   - ruby-head
   - jruby-9.1.9.0
   - jruby-head


### PR DESCRIPTION
Ruby 3.0 has been released in 2020, and Ruby 3.1 has been released in 2021. Let's support them.

https://www.ruby-lang.org/en/downloads/branches/