### PR TITLE
Drop lazy priority queue

### DIFF
--- a/lib/rgl/bellman_ford.rb
+++ b/lib/rgl/bellman_ford.rb
@@ -2,8 +2,6 @@ require 'rgl/dijkstra_visitor'
 require 'rgl/edge_properties_map'
 require 'rgl/path_builder'
 
-require 'lazy_priority_queue'
-
 module RGL
 
   # Bellman-Ford shortest paths algorithm has the following event points:

--- a/lib/rgl/dijkstra.rb
+++ b/lib/rgl/dijkstra.rb
@@ -2,7 +2,7 @@ require 'rgl/dijkstra_visitor'
 require 'rgl/edge_properties_map'
 require 'rgl/path_builder'
 
-require 'lazy_priority_queue'
+require 'pairing_heap'
 
 module RGL
 
@@ -54,7 +54,7 @@ module RGL
     def init(source)
       @visitor.set_source(source)
 
-      @queue = MinPriorityQueue.new
+      @queue = PairingHeap::MinPriorityQueue.new
       @queue.push(source, 0)
     end
 

--- a/rgl.gemspec
+++ b/rgl.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   #### Dependencies and requirements.
 
   s.add_dependency 'stream',     '~> 0.5.3'
-  s.add_dependency 'lazy_priority_queue', '~> 0.1.0'
+  s.add_dependency 'pairing_heap', '>= 0.3.0'
   s.add_dependency 'rexml', '~> 3.2', '>= 3.2.4'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
[lazy_priority_queue](https://github.com/matiasbattocchia/lazy_priority_queue) is unfortunately unmaintained. [pairing_heap](https://github.com/mhib/pairing_heap) is a drop in replacement, that is maintained and faster in benchmarks.