### PR TITLE
 feat: implement bidirectional adjacency graph

### DIFF
--- a/lib/rgl/base.rb
+++ b/lib/rgl/base.rb
@@ -192,6 +192,15 @@ module RGL
       include?(v) # inherited from enumerable
     end
 
+    # Returns true if +(u, v)+ is an edge of the graph.
+    # @param (see #each_edge)
+    def has_edge?(u, v)
+      each_adjacent(u) do |w|
+        return true if v == w
+      end
+      return false
+    end
+
     # Returns true if the graph has no vertices, i.e. num_vertices == 0.
     #
     def empty?

--- a/lib/rgl/bidirectional.rb
+++ b/lib/rgl/bidirectional.rb
@@ -56,7 +56,7 @@ module RGL
     # and the source is required to be a vertex that is adjacent to _v_.
     #
     def each_in_neighbor(v)
-      @reverse.each_adjacent
+      @reverse.each_adjacent(v)
     end
 
     alias :each_out_neighbor :each_adjacent

--- a/lib/rgl/bidirectional.rb
+++ b/lib/rgl/bidirectional.rb
@@ -26,6 +26,20 @@ module RGL
       yield u
     end
 
+    alias :each_out_neighbor :each_adjacent
+
+    def has_in_edge?(u, v)
+      raise NotImplementedError
+    end
+
+    alias :has_out_edge? :has_edge?
+
+    def in_neighbors(v)
+      raise NotImplementedError
+    end
+
+    alias :out_neighbors :adjacent_vertices
+
     # Returns the number of in-edges (for directed graphs) or the number of
     # incident edges (for undirected graphs) of vertex _v_.
     # @return [int]

--- a/lib/rgl/bidirectional.rb
+++ b/lib/rgl/bidirectional.rb
@@ -43,7 +43,7 @@ module RGL
     end
 
     def has_in_edge?(u, v)
-      @reverse.has_edge?(v, u)
+      @reverse.has_edge?(u, v)
     end
 
     alias :has_out_edge? :has_edge?

--- a/lib/rgl/bidirectional.rb
+++ b/lib/rgl/bidirectional.rb
@@ -1,7 +1,4 @@
-# bidirectional.rb
-#
-require 'delegate'
-require 'rgl/adjacency'
+require 'rgl/base'
 
 module RGL
 
@@ -15,42 +12,9 @@ module RGL
   # graphs, this is not an issue; because the in_edges() and out_edges()
   # functions are the same, they both return the edges incident to the vertex.
   #
-  class BidirectionalGraph < DirectedAdjacencyGraph
+  module BidirectionalGraph
 
     include Graph
-
-    def initialize(edgelist_class = Set, *other_graphs)
-      super(edgelist_class, *other_graphs)
-      @reverse = self.reverse
-    end
-
-    # We don't need to override add_vertex() because the reverse graph doesn't need to
-    # contain any unconnected vertices. Vertices will be added by add_edge() as
-    # required.
-    #
-    # @see MutableGraph#add_edge.
-    def add_edge(u, v)
-      super(u, v)
-      @reverse.add_edge(v, u)
-    end
-
-    # @see MutableGraph#remove_vertex.
-    def remove_vertex(v)
-      super(v)
-      @reverse.remove_vertex(v)
-    end
-
-    # @see MutableGraph::remove_edge.
-    def remove_edge(u, v)
-      super(u, v)
-      @reverse.remove_edge(v, u)
-    end
-
-    def has_in_edge?(u, v)
-      @reverse.has_edge?(u, v)
-    end
-
-    alias :has_out_edge? :has_edge?
 
     # Iterator providing access to the in-edges (for directed graphs) or incident
     # edges (for undirected graphs) of vertex _v_. For both directed and
@@ -58,22 +22,17 @@ module RGL
     # and the source is required to be a vertex that is adjacent to _v_.
     #
     def each_in_neighbor(v)
-      @reverse.each_adjacent(v)
+      raise NotImplementedError
+      yield u
     end
-
-    alias :each_out_neighbor :each_adjacent
-
-    def in_neighbors(v)
-      @reverse.adjacent_vertices(v)
-    end
-
-    alias :out_neighbors :adjacent_vertices
 
     # Returns the number of in-edges (for directed graphs) or the number of
     # incident edges (for undirected graphs) of vertex _v_.
     # @return [int]
     def in_degree(v)
-      @reverse.out_degree(v)
+      r = 0
+      each_in_neighbor(v) { |u| r += 1 }
+      r
     end
 
     # Returns the number of in-edges plus out-edges (for directed graphs) or the

--- a/lib/rgl/bidirectional.rb
+++ b/lib/rgl/bidirectional.rb
@@ -1,3 +1,5 @@
+# bidirectional.rb
+#
 require 'delegate'
 require 'rgl/adjacency'
 
@@ -23,7 +25,7 @@ module RGL
     end
 
     # We don't need to override add_vertex() because the reverse graph doesn't need to
-    # contain any unconnected vertices. Vertices will be added by add_vertex() as
+    # contain any unconnected vertices. Vertices will be added by add_edge() as
     # required.
     #
     # @see MutableGraph#add_edge.

--- a/lib/rgl/bidirectional.rb
+++ b/lib/rgl/bidirectional.rb
@@ -22,11 +22,6 @@ module RGL
       @reverse = self.reverse
     end
 
-    def add_vertex(v)
-      super(v)
-      @reverse.add_vertex(v)
-    end
-
     def add_edge(u, v)
       super(u, v)
       @reverse.add_edge(v, u)

--- a/lib/rgl/bidirectional.rb
+++ b/lib/rgl/bidirectional.rb
@@ -22,16 +22,23 @@ module RGL
       @reverse = self.reverse
     end
 
+    # We don't need to override add_vertex() because the reverse graph doesn't need to
+    # contain any unconnected vertices. Vertices will be added by add_vertex() as
+    # required.
+    #
+    # @see MutableGraph#add_edge.
     def add_edge(u, v)
       super(u, v)
       @reverse.add_edge(v, u)
     end
 
+    # @see MutableGraph#remove_vertex.
     def remove_vertex(v)
       super(v)
       @reverse.remove_vertex(v)
     end
 
+    # @see MutableGraph::remove_edge.
     def remove_edge(u, v)
       super(u, v)
       @reverse.remove_edge(v, u)

--- a/lib/rgl/bidirectional.rb
+++ b/lib/rgl/bidirectional.rb
@@ -1,4 +1,5 @@
-require 'rgl/base'
+require 'delegate'
+require 'rgl/adjacency'
 
 module RGL
 
@@ -12,9 +13,40 @@ module RGL
   # graphs, this is not an issue; because the in_edges() and out_edges()
   # functions are the same, they both return the edges incident to the vertex.
   #
-  module BidirectionalGraph
+  class BidirectionalGraph < DirectedAdjacencyGraph
 
     include Graph
+
+    def initialize(edgelist_class = Set, *other_graphs)
+      super(edgelist_class, *other_graphs)
+      @reverse = self.reverse
+    end
+
+    def add_vertex(v)
+      super(v)
+      @reverse.add_vertex(v)
+    end
+
+    def add_edge(u, v)
+      super(u, v)
+      @reverse.add_edge(v, u)
+    end
+
+    def remove_vertex(v)
+      super(v)
+      @reverse.remove_vertex(v)
+    end
+
+    def remove_edge(u, v)
+      super(u, v)
+      @reverse.remove_edge(v, u)
+    end
+
+    def has_in_edge?(u, v)
+      @reverse.has_edge?(v, u)
+    end
+
+    alias :has_out_edge? :has_edge?
 
     # Iterator providing access to the in-edges (for directed graphs) or incident
     # edges (for undirected graphs) of vertex _v_. For both directed and
@@ -22,17 +54,22 @@ module RGL
     # and the source is required to be a vertex that is adjacent to _v_.
     #
     def each_in_neighbor(v)
-      raise NotImplementedError
-      yield u
+      @reverse.each_adjacent
     end
+
+    alias :each_out_neighbor :each_adjacent
+
+    def in_neighbors(v)
+      @reverse.adjacent_vertices(v)
+    end
+
+    alias :out_neighbors :adjacent_vertices
 
     # Returns the number of in-edges (for directed graphs) or the number of
     # incident edges (for undirected graphs) of vertex _v_.
     # @return [int]
     def in_degree(v)
-      r = 0
-      each_in_neighbor(v) { |u| r += 1 }
-      r
+      @reverse.out_degree(v)
     end
 
     # Returns the number of in-edges plus out-edges (for directed graphs) or the

--- a/lib/rgl/bidirectional_adjacency.rb
+++ b/lib/rgl/bidirectional_adjacency.rb
@@ -15,8 +15,8 @@ module RGL
 
     # @see DirectedAdjacencyGraph#initialize
     def initialize(edgelist_class = Set, *other_graphs)
+      @reverse = DirectedAdjacencyGraph.new(edgelist_class)
       super(edgelist_class, *other_graphs)
-      @reverse = self.reverse
     end
 
     # We don't need to override add_vertex() because the reverse graph doesn't need to

--- a/lib/rgl/bidirectional_adjacency.rb
+++ b/lib/rgl/bidirectional_adjacency.rb
@@ -5,19 +5,9 @@ require 'rgl/bidirectional'
 
 module RGL
 
-  # BGL defines the concept BidirectionalGraph as follows:
-  #
-  # The BidirectionalGraph concept refines IncidenceGraph and adds the
-  # requirement for efficient access to the in-edges of each vertex. This
-  # concept is separated from IncidenceGraph because, for directed graphs,
-  # efficient access to in-edges typically requires more storage space,
-  # and many algorithms do not require access to in-edges. For undirected
-  # graphs, this is not an issue; because the in_edges() and out_edges()
-  # functions are the same, they both return the edges incident to the vertex.
-
-  # This implementation simply creates an internal DirectedAdjacencyGraph to store
-  # the in-edges and overrides methods to ensure that the out and in graphs
-  # remain synchronized.
+  # This implementation of @see BidirectionalGraph creates an internal
+  # DirectedAdjacencyGraph to store the in-edges and overrides methods
+  # to ensure that the out and in graphs remain synchronized.
   #
   class BidirectionalAdjacencyGraph < DirectedAdjacencyGraph
 
@@ -58,11 +48,7 @@ module RGL
 
     alias :has_out_edge? :has_edge?
 
-    # Iterator providing access to the in-edges (for directed graphs) or incident
-    # edges (for undirected graphs) of vertex _v_. For both directed and
-    # undirected graphs, the target of an out-edge is required to be vertex _v_
-    # and the source is required to be a vertex that is adjacent to _v_.
-    #
+    # @see BidirectionalGraph#each_in_neighbor
     def each_in_neighbor(v)
       @reverse.each_adjacent(v)
     end
@@ -72,8 +58,6 @@ module RGL
     def in_neighbors(v)
       @reverse.adjacent_vertices(v)
     end
-
-    alias :out_neighbors :adjacent_vertices
 
     # Returns the number of in-edges (for directed graphs) or the number of
     # incident edges (for undirected graphs) of vertex _v_.

--- a/lib/rgl/bidirectional_adjacency.rb
+++ b/lib/rgl/bidirectional_adjacency.rb
@@ -1,0 +1,81 @@
+# bidirectional.rb
+#
+require 'rgl/adjacency'
+require 'rgl/bidirectional'
+
+module RGL
+
+  # BGL defines the concept BidirectionalGraph as follows:
+  #
+  # The BidirectionalGraph concept refines IncidenceGraph and adds the
+  # requirement for efficient access to the in-edges of each vertex. This
+  # concept is separated from IncidenceGraph because, for directed graphs,
+  # efficient access to in-edges typically requires more storage space,
+  # and many algorithms do not require access to in-edges. For undirected
+  # graphs, this is not an issue; because the in_edges() and out_edges()
+  # functions are the same, they both return the edges incident to the vertex.
+  #
+  class BidirectionalAdjacencyGraph < DirectedAdjacencyGraph
+
+    include BidirectionalGraph
+
+    def initialize(edgelist_class = Set, *other_graphs)
+      super(edgelist_class, *other_graphs)
+      @reverse = self.reverse
+    end
+
+    # We don't need to override add_vertex() because the reverse graph doesn't need to
+    # contain any unconnected vertices. Vertices will be added by add_edge() as
+    # required.
+    #
+    # @see MutableGraph#add_edge.
+    def add_edge(u, v)
+      super(u, v)
+      @reverse.add_edge(v, u)
+    end
+
+    # @see MutableGraph#remove_vertex.
+    def remove_vertex(v)
+      super(v)
+      @reverse.remove_vertex(v)
+    end
+
+    # @see MutableGraph::remove_edge.
+    def remove_edge(u, v)
+      super(u, v)
+      @reverse.remove_edge(v, u)
+    end
+
+    def has_in_edge?(u, v)
+      @reverse.has_edge?(u, v)
+    end
+
+    alias :has_out_edge? :has_edge?
+
+    # Iterator providing access to the in-edges (for directed graphs) or incident
+    # edges (for undirected graphs) of vertex _v_. For both directed and
+    # undirected graphs, the target of an out-edge is required to be vertex _v_
+    # and the source is required to be a vertex that is adjacent to _v_.
+    #
+    def each_in_neighbor(v)
+      @reverse.each_adjacent(v)
+    end
+
+    alias :each_out_neighbor :each_adjacent
+
+    def in_neighbors(v)
+      @reverse.adjacent_vertices(v)
+    end
+
+    alias :out_neighbors :adjacent_vertices
+
+    # Returns the number of in-edges (for directed graphs) or the number of
+    # incident edges (for undirected graphs) of vertex _v_.
+    # @return [int]
+    def in_degree(v)
+      @reverse.out_degree(v)
+    end
+
+ end
+
+end

--- a/lib/rgl/bidirectional_adjacency.rb
+++ b/lib/rgl/bidirectional_adjacency.rb
@@ -14,6 +14,7 @@ module RGL
     include BidirectionalGraph
 
     # @see DirectedAdjacencyGraph#initialize
+    # In super method the in edges are also added since `add_edge` of this class also inserts edges in `@reverse`.
     def initialize(edgelist_class = Set, *other_graphs)
       @reverse = DirectedAdjacencyGraph.new(edgelist_class)
       super(edgelist_class, *other_graphs)

--- a/lib/rgl/bidirectional_adjacency.rb
+++ b/lib/rgl/bidirectional_adjacency.rb
@@ -1,4 +1,4 @@
-# bidirectional.rb
+# bidirectional_adjacency.rb
 #
 require 'rgl/adjacency'
 require 'rgl/bidirectional'
@@ -14,11 +14,16 @@ module RGL
   # and many algorithms do not require access to in-edges. For undirected
   # graphs, this is not an issue; because the in_edges() and out_edges()
   # functions are the same, they both return the edges incident to the vertex.
+
+  # This implementation simply creates an internal DirectedAdjacencyGraph to store
+  # the in-edges and overrides methods to ensure that the out and in graphs
+  # remain synchronized.
   #
   class BidirectionalAdjacencyGraph < DirectedAdjacencyGraph
 
     include BidirectionalGraph
 
+    # @see DirectedAdjacencyGraph#initialize
     def initialize(edgelist_class = Set, *other_graphs)
       super(edgelist_class, *other_graphs)
       @reverse = self.reverse
@@ -27,7 +32,7 @@ module RGL
     # We don't need to override add_vertex() because the reverse graph doesn't need to
     # contain any unconnected vertices. Vertices will be added by add_edge() as
     # required.
-    #
+
     # @see MutableGraph#add_edge.
     def add_edge(u, v)
       super(u, v)
@@ -46,6 +51,7 @@ module RGL
       @reverse.remove_edge(v, u)
     end
 
+    # @see Graph#has_edge?
     def has_in_edge?(u, v)
       @reverse.has_edge?(u, v)
     end

--- a/test/bidirectional_graph_test.rb
+++ b/test/bidirectional_graph_test.rb
@@ -6,18 +6,7 @@ require 'directed_graph_test'
 include RGL
 include RGL::Edge
 
-class TestBidirectionalAdjacencyGraphBasic < TestDirectedGraph
-  def setup
-    @dg = BidirectionalAdjacencyGraph.new
-    [[1, 2], [2, 3], [3, 2], [2, 4]].each do |(src, target)|
-      # @dg.add_edge(src, target)
-    end
-    @eg = BidirectionalAdjacencyGraph.new
-    @gfa = BidirectionalAdjacencyGraph[1, 2]
-  end
-end
-
-class TestBidirectionalAdjacencyGraphExtended < Test::Unit::TestCase
+class TestBidirectionalAdjacencyGraph < Test::Unit::TestCase
   def setup
     @edges = [[1, 2], [1, 3], [2, 3], [2, 4], [2, 5], [2, 6], [3, 2], [3, 7], [3, 8],
              [5, 10], [6, 9], [7, 9], [7, 10], [8, 10]]
@@ -31,10 +20,12 @@ class TestBidirectionalAdjacencyGraphExtended < Test::Unit::TestCase
     @edges.each do |(src, target)|
       @dg.add_edge(src, target)
     end
+    @eg = BidirectionalAdjacencyGraph.new
+    @gfa = BidirectionalAdjacencyGraph[1, 2, 3, 4]
   end
 
   def test_empty_graph
-    dg = BidirectionalAdjacencyGraph.new
+    dg = @eg.clone
     assert dg.empty?
     assert dg.directed?
     assert(!dg.has_edge?(2, 1))
@@ -54,7 +45,7 @@ class TestBidirectionalAdjacencyGraphExtended < Test::Unit::TestCase
   end
 
   def test_add
-    dg = BidirectionalAdjacencyGraph.new
+    dg = @eg.clone
     dg.add_edge(1, 2)
     assert(!dg.empty?)
     assert(dg.has_edge?(1, 2))
@@ -121,7 +112,7 @@ class TestBidirectionalAdjacencyGraphExtended < Test::Unit::TestCase
   end
 
   def test_add_vertices
-    dg = BidirectionalAdjacencyGraph.new
+    dg = @eg.clone
     dg.add_vertices 1, 3, 2, 4
     assert_equal dg.vertices.sort, [1, 2, 3, 4]
 
@@ -130,17 +121,25 @@ class TestBidirectionalAdjacencyGraphExtended < Test::Unit::TestCase
   end
 
   def test_creating_from_array
-    dg = BidirectionalAdjacencyGraph[1, 2, 3, 4]
+    dg = @gfa.clone
     assert_equal([1, 2, 3, 4], dg.vertices.sort)
     assert_equal('(1-2)(3-4)', dg.edges.join)
   end
 
-  def test_reverse
-    # Add isolated vertex
-    @dg.add_vertex(42)
-    reverted = @dg.reverse
+  def test_creating_from_graphs
+    dg = @dg.clone
+    @gfa.each_edge { |e| dg.add_edge(e[0], e[1])}
+    dg2 = BidirectionalAdjacencyGraph.new(Set, @dg, @gfa)
+    assert_equal(dg2, dg2)
+  end
 
-    @dg.each_edge do |u, v|
+  def test_reverse
+    dg = @dg.clone
+    # Add isolated vertex
+    dg.add_vertex(42)
+    reverted = dg.reverse
+
+    dg.each_edge do |u, v|
       assert(reverted.has_edge?(v, u))
     end
 

--- a/test/bidirectional_graph_test.rb
+++ b/test/bidirectional_graph_test.rb
@@ -1,11 +1,23 @@
 require 'test_helper'
 
 require 'rgl/bidirectional_adjacency'
+require 'directed_graph_test'
 
 include RGL
 include RGL::Edge
 
-class TestBidirectionalAdjacencyGraph < Test::Unit::TestCase
+class TestBidirectionalAdjacencyGraphBasic < TestDirectedGraph
+  def setup
+    @dg = BidirectionalAdjacencyGraph.new
+    [[1, 2], [2, 3], [3, 2], [2, 4]].each do |(src, target)|
+      # @dg.add_edge(src, target)
+    end
+    @eg = BidirectionalAdjacencyGraph.new
+    @gfa = BidirectionalAdjacencyGraph[1, 2]
+  end
+end
+
+class TestBidirectionalAdjacencyGraphExtended < Test::Unit::TestCase
   def setup
     @edges = [[1, 2], [1, 3], [2, 3], [2, 4], [2, 5], [2, 6], [3, 2], [3, 7], [3, 8],
              [5, 10], [6, 9], [7, 9], [7, 10], [8, 10]]
@@ -163,3 +175,4 @@ class TestBidirectionalAdjacencyGraph < Test::Unit::TestCase
   end
 
 end
+

--- a/test/bidirectional_graph_test.rb
+++ b/test/bidirectional_graph_test.rb
@@ -1,0 +1,119 @@
+require 'test_helper'
+
+require 'rgl/adjacency'
+require 'rgl/bidirectional'
+
+include RGL
+include RGL::Edge
+
+class TestBidirectionalGraph < Test::Unit::TestCase
+  def setup
+    @dg = BidirectionalGraph.new
+    [[1, 2], [2, 3], [3, 2], [2, 4]].each do |(src, target)|
+      @dg.add_edge(src, target)
+    end
+  end
+
+  def test_empty_graph
+    dg = BidirectionalGraph.new
+    assert dg.empty?
+    assert dg.directed?
+    assert(!dg.has_edge?(2, 1))
+    assert(!dg.has_vertex?(3))
+    # Non existent vertex result in a Name Error because each_key is
+    # called for nil
+    assert_raises(NoVertexError) { dg.out_degree(3) }
+    assert_equal([], dg.vertices)
+    assert_equal(0, dg.size)
+    assert_equal(0, dg.num_vertices)
+    assert_equal(0, dg.num_edges)
+    assert_equal(DirectedEdge, dg.edge_class)
+    assert([].eql?(dg.edges))
+  end
+
+  def test_add
+    dg = BidirectionalGraph.new
+    dg.add_edge(1, 2)
+    assert(!dg.empty?)
+    assert(dg.has_edge?(1, 2))
+    assert(!dg.has_edge?(2, 1))
+    assert(dg.has_vertex?(1) && dg.has_vertex?(2))
+    assert(!dg.has_vertex?(3))
+
+    assert_equal([1, 2], dg.vertices.sort)
+    assert([DirectedEdge.new(1, 2)].eql?(dg.edges))
+    assert_equal("(1-2)", dg.edges.join)
+
+    assert_equal([2], dg.adjacent_vertices(1))
+    assert_equal([], dg.adjacent_vertices(2))
+
+    assert_equal(1, dg.out_degree(1))
+    assert_equal(0, dg.out_degree(2))
+  end
+
+  def test_edges
+    assert_equal(4, @dg.edges.length)
+    assert_equal([1, 2, 2, 3], @dg.edges.map { |l| l.source }.sort)
+    assert_equal([2, 2, 3, 4], @dg.edges.map { |l| l.target }.sort)
+    assert_equal("(1-2)(2-3)(2-4)(3-2)", @dg.edges.map { |l| l.to_s }.sort.join)
+    #    assert_equal([0,1,2,3], @dg.edges.map {|l| l.info}.sort)
+  end
+
+  def test_vertices
+    assert_equal([1, 2, 3, 4], @dg.vertices.sort)
+  end
+
+  def test_edges_from_to?
+    assert @dg.has_edge?(1, 2)
+    assert @dg.has_edge?(2, 3)
+    assert @dg.has_edge?(3, 2)
+    assert @dg.has_edge?(2, 4)
+    assert !@dg.has_edge?(2, 1)
+    assert !@dg.has_edge?(3, 1)
+    assert !@dg.has_edge?(4, 1)
+    assert !@dg.has_edge?(4, 2)
+  end
+
+  def test_remove_edges
+    @dg.remove_edge 1, 2
+    assert !@dg.has_edge?(1, 2)
+    @dg.remove_edge 1, 2
+    assert !@dg.has_edge?(1, 2)
+    @dg.remove_vertex 3
+    assert !@dg.has_vertex?(3)
+    assert !@dg.has_edge?(2, 3)
+    assert_equal('(2-4)', @dg.edges.join)
+  end
+
+  def test_add_vertices
+    dg = BidirectionalGraph.new
+    dg.add_vertices 1, 3, 2, 4
+    assert_equal dg.vertices.sort, [1, 2, 3, 4]
+
+    dg.remove_vertices 1, 3
+    assert_equal dg.vertices.sort, [2, 4]
+  end
+
+  def test_creating_from_array
+    dg = BidirectionalGraph[1, 2, 3, 4]
+    assert_equal([1, 2, 3, 4], dg.vertices.sort)
+    assert_equal('(1-2)(3-4)', dg.edges.join)
+  end
+
+  def test_reverse
+    # Add isolated vertex
+    @dg.add_vertex(42)
+    reverted = @dg.reverse
+
+    @dg.each_edge do |u, v|
+      assert(reverted.has_edge?(v, u))
+    end
+
+    assert(reverted.has_vertex?(42), 'Reverted graph should contain isolated Vertex 42')
+  end
+
+  def test_to_undirected
+    undirected = @dg.to_undirected
+    assert_equal '(1=2)(2=3)(2=4)', undirected.edges.sort.join
+  end
+end

--- a/test/bidirectional_graph_test.rb
+++ b/test/bidirectional_graph_test.rb
@@ -10,6 +10,12 @@ class TestBidirectionalGraph < Test::Unit::TestCase
   def setup
     @edges = [[1, 2], [1, 3], [2, 3], [2, 4], [2, 5], [2, 6], [3, 2], [3, 7], [3, 8],
              [5, 10], [6, 9], [7, 9], [7, 10], [8, 10]]
+    @out_neighbors = Hash.new { |h, k| h[k] = Set.new }
+    @in_neighbors = Hash.new { |h, k| h[k] = Set.new }
+    @edges.each do |e|
+      @out_neighbors[e[0]] << e[1]
+      @in_neighbors[e[1]] << e[0]
+    end
     @dg = BidirectionalGraph.new
     @edges.each do |(src, target)|
       @dg.add_edge(src, target)
@@ -134,4 +140,27 @@ class TestBidirectionalGraph < Test::Unit::TestCase
     undirected = @dg.to_undirected
     assert_equal '(1=2)(1=3)(2=3)(2=4)(2=5)(2=6)(3=7)(3=8)(5=10)(6=9)(7=9)(7=10)(8=10)', undirected.edges.sort.join
   end
+
+  def test_neighbors
+    @edges.flatten.to_set.each do |v|
+      assert_equal @out_neighbors[v], @dg.out_neighbors(v).to_set
+      assert_equal @in_neighbors[v], @dg.in_neighbors(v).to_set
+    end
+  end
+
+  def test_each_neighbor
+    @edges.flatten.to_set.each do |v|
+      assert_equal @out_neighbors[v], @dg.each_out_neighbor(v).inject(Set.new) { |s, v| s << v }
+      assert_equal @in_neighbors[v], @dg.each_in_neighbor(v).inject(Set.new) { |s, v| s << v }
+    end
+  end
+
+  def test_degrees
+    @edges.flatten.to_set.each do |v|
+      assert_equal @out_neighbors[v].size, @dg.out_degree(v)
+      assert_equal @in_neighbors[v].size, @dg.in_degree(v)
+      assert_equal @out_neighbors[v].size + @in_neighbors[v].size, @dg.degree(v)
+    end
+  end
+
 end

--- a/test/bidirectional_graph_test.rb
+++ b/test/bidirectional_graph_test.rb
@@ -25,53 +25,51 @@ class TestBidirectionalAdjacencyGraph < Test::Unit::TestCase
   end
 
   def test_empty_graph
-    dg = @eg.clone
-    assert dg.empty?
-    assert dg.directed?
-    assert(!dg.has_edge?(2, 1))
-    assert(!dg.has_out_edge?(2, 1))
-    assert(!dg.has_in_edge?(1, 2))
-    assert(!dg.has_vertex?(3))
+    assert @eg.empty?
+    assert @eg.directed?
+    assert(!@eg.has_edge?(2, 1))
+    assert(!@eg.has_out_edge?(2, 1))
+    assert(!@eg.has_in_edge?(1, 2))
+    assert(!@eg.has_vertex?(3))
     # Non existent vertex result in a Name Error because each_key is
     # called for nil
-    assert_raises(NoVertexError) { dg.out_degree(3) }
-    assert_raises(NoVertexError) { dg.in_degree(3) }
-    assert_equal([], dg.vertices)
-    assert_equal(0, dg.size)
-    assert_equal(0, dg.num_vertices)
-    assert_equal(0, dg.num_edges)
-    assert_equal(DirectedEdge, dg.edge_class)
-    assert([].eql?(dg.edges))
+    assert_raises(NoVertexError) { @eg.out_degree(3) }
+    assert_raises(NoVertexError) { @eg.in_degree(3) }
+    assert_equal([], @eg.vertices)
+    assert_equal(0, @eg.size)
+    assert_equal(0, @eg.num_vertices)
+    assert_equal(0, @eg.num_edges)
+    assert_equal(DirectedEdge, @eg.edge_class)
+    assert_empty(@eg.edges)
   end
 
   def test_add
-    dg = @eg.clone
-    dg.add_edge(1, 2)
-    assert(!dg.empty?)
-    assert(dg.has_edge?(1, 2))
-    assert(dg.has_out_edge?(1, 2))
-    assert(dg.has_in_edge?(2, 1))
-    assert(!dg.has_edge?(2, 1))
-    assert(!dg.has_out_edge?(2, 1))
-    assert(!dg.has_in_edge?(1, 2))
-    assert(dg.has_vertex?(1) && dg.has_vertex?(2))
-    assert(!dg.has_vertex?(3))
+    @eg.add_edge(1, 2)
+    assert(!@eg.empty?)
+    assert(@eg.has_edge?(1, 2))
+    assert(@eg.has_out_edge?(1, 2))
+    assert(@eg.has_in_edge?(2, 1))
+    assert(!@eg.has_edge?(2, 1))
+    assert(!@eg.has_out_edge?(2, 1))
+    assert(!@eg.has_in_edge?(1, 2))
+    assert(@eg.has_vertex?(1) && @eg.has_vertex?(2))
+    assert(!@eg.has_vertex?(3))
 
-    assert_equal([1, 2], dg.vertices.sort)
-    assert([DirectedEdge.new(1, 2)].eql?(dg.edges))
-    assert_equal("(1-2)", dg.edges.join)
+    assert_equal([1, 2], @eg.vertices.sort)
+    assert([DirectedEdge.new(1, 2)].eql?(@eg.edges))
+    assert_equal("(1-2)", @eg.edges.join)
 
-    assert_equal([2], dg.adjacent_vertices(1))
-    assert_equal([2], dg.out_neighbors(1))
-    assert_equal([], dg.in_neighbors(1))
-    assert_equal([], dg.adjacent_vertices(2))
-    assert_equal([], dg.out_neighbors(2))
-    assert_equal([1], dg.in_neighbors(2))
+    assert_equal([2], @eg.adjacent_vertices(1))
+    assert_equal([2], @eg.out_neighbors(1))
+    assert_equal([], @eg.in_neighbors(1))
+    assert_equal([], @eg.adjacent_vertices(2))
+    assert_equal([], @eg.out_neighbors(2))
+    assert_equal([1], @eg.in_neighbors(2))
 
-    assert_equal(1, dg.out_degree(1))
-    assert_equal(0, dg.in_degree(1))
-    assert_equal(0, dg.out_degree(2))
-    assert_equal(1, dg.in_degree(2))
+    assert_equal(1, @eg.out_degree(1))
+    assert_equal(0, @eg.in_degree(1))
+    assert_equal(0, @eg.out_degree(2))
+    assert_equal(1, @eg.in_degree(2))
   end
 
   def test_edges
@@ -79,7 +77,6 @@ class TestBidirectionalAdjacencyGraph < Test::Unit::TestCase
     assert_equal(@edges.map { |e| e[0] }.to_set, @dg.edges.map { |l| l.source }.to_set)
     assert_equal(@edges.map { |e| e[1] }.to_set, @dg.edges.map { |l| l.target }.to_set)
     assert_equal("(1-2)(1-3)(2-3)(2-4)(2-5)(2-6)(3-2)(3-7)(3-8)(5-10)(6-9)(7-10)(7-9)(8-10)", @dg.edges.map { |l| l.to_s }.sort.join)
-    #    assert_equal([0,1,2,3], @dg.edges.map {|l| l.info}.sort)
   end
 
   def test_vertices
@@ -112,34 +109,30 @@ class TestBidirectionalAdjacencyGraph < Test::Unit::TestCase
   end
 
   def test_add_vertices
-    dg = @eg.clone
-    dg.add_vertices 1, 3, 2, 4
-    assert_equal dg.vertices.sort, [1, 2, 3, 4]
+    @eg.add_vertices 1, 3, 2, 4
+    assert_equal @eg.vertices.sort, [1, 2, 3, 4]
 
-    dg.remove_vertices 1, 3
-    assert_equal dg.vertices.sort, [2, 4]
+    @eg.remove_vertices 1, 3
+    assert_equal @eg.vertices.sort, [2, 4]
   end
 
   def test_creating_from_array
-    dg = @gfa.clone
-    assert_equal([1, 2, 3, 4], dg.vertices.sort)
-    assert_equal('(1-2)(3-4)', dg.edges.join)
+    assert_equal([1, 2, 3, 4], @gfa.vertices.sort)
+    assert_equal('(1-2)(3-4)', @gfa.edges.join)
   end
 
   def test_creating_from_graphs
-    dg = @dg.clone
-    @gfa.each_edge { |e| dg.add_edge(e[0], e[1])}
     dg2 = BidirectionalAdjacencyGraph.new(Set, @dg, @gfa)
-    assert_equal(dg2, dg2)
+    assert_equal(dg2.vertices.to_set, (@dg.vertices + @gfa.vertices).to_set)
+    assert_equal(dg2.edges.to_set, (@dg.edges + @gfa.edges).to_set)
   end
 
   def test_reverse
-    dg = @dg.clone
     # Add isolated vertex
-    dg.add_vertex(42)
-    reverted = dg.reverse
+    @dg.add_vertex(42)
+    reverted = @dg.reverse
 
-    dg.each_edge do |u, v|
+    @dg.each_edge do |u, v|
       assert(reverted.has_edge?(v, u))
     end
 

--- a/test/bidirectional_graph_test.rb
+++ b/test/bidirectional_graph_test.rb
@@ -19,10 +19,13 @@ class TestBidirectionalGraph < Test::Unit::TestCase
     assert dg.empty?
     assert dg.directed?
     assert(!dg.has_edge?(2, 1))
+    assert(!dg.has_out_edge?(2, 1))
+    assert(!dg.has_in_edge?(1, 2))
     assert(!dg.has_vertex?(3))
     # Non existent vertex result in a Name Error because each_key is
     # called for nil
     assert_raises(NoVertexError) { dg.out_degree(3) }
+    assert_raises(NoVertexError) { dg.in_degree(3) }
     assert_equal([], dg.vertices)
     assert_equal(0, dg.size)
     assert_equal(0, dg.num_vertices)
@@ -36,7 +39,11 @@ class TestBidirectionalGraph < Test::Unit::TestCase
     dg.add_edge(1, 2)
     assert(!dg.empty?)
     assert(dg.has_edge?(1, 2))
+    assert(dg.has_out_edge?(1, 2))
+    assert(dg.has_in_edge?(2, 1))
     assert(!dg.has_edge?(2, 1))
+    assert(!dg.has_out_edge?(2, 1))
+    assert(!dg.has_in_edge?(1, 2))
     assert(dg.has_vertex?(1) && dg.has_vertex?(2))
     assert(!dg.has_vertex?(3))
 
@@ -45,10 +52,16 @@ class TestBidirectionalGraph < Test::Unit::TestCase
     assert_equal("(1-2)", dg.edges.join)
 
     assert_equal([2], dg.adjacent_vertices(1))
+    assert_equal([2], dg.out_neighbors(1))
+    assert_equal([], dg.in_neighbors(1))
     assert_equal([], dg.adjacent_vertices(2))
+    assert_equal([], dg.out_neighbors(2))
+    assert_equal([1], dg.in_neighbors(2))
 
     assert_equal(1, dg.out_degree(1))
+    assert_equal(0, dg.in_degree(1))
     assert_equal(0, dg.out_degree(2))
+    assert_equal(1, dg.in_degree(2))
   end
 
   def test_edges
@@ -65,23 +78,45 @@ class TestBidirectionalGraph < Test::Unit::TestCase
 
   def test_edges_from_to?
     assert @dg.has_edge?(1, 2)
+    assert @dg.has_out_edge?(1, 2)
+    assert @dg.has_in_edge?(2, 1)
     assert @dg.has_edge?(2, 3)
+    assert @dg.has_out_edge?(2, 3)
+    assert @dg.has_in_edge?(3, 2)
     assert @dg.has_edge?(3, 2)
+    assert @dg.has_out_edge?(3, 2)
+    assert @dg.has_in_edge?(2, 3)
     assert @dg.has_edge?(2, 4)
+    assert @dg.has_out_edge?(2, 4)
+    assert @dg.has_in_edge?(4, 2)
     assert !@dg.has_edge?(2, 1)
+    assert !@dg.has_out_edge?(2, 1)
+    assert !@dg.has_in_edge?(1, 2)
     assert !@dg.has_edge?(3, 1)
+    assert !@dg.has_out_edge?(3, 1)
+    assert !@dg.has_in_edge?(1, 3)
     assert !@dg.has_edge?(4, 1)
+    assert !@dg.has_out_edge?(4, 1)
+    assert !@dg.has_in_edge?(1, 4)
     assert !@dg.has_edge?(4, 2)
+    assert !@dg.has_out_edge?(4, 2)
+    assert !@dg.has_in_edge?(2, 4)
   end
 
   def test_remove_edges
     @dg.remove_edge 1, 2
     assert !@dg.has_edge?(1, 2)
+    assert !@dg.has_out_edge?(1, 2)
+    assert !@dg.has_in_edge?(2, 1)
     @dg.remove_edge 1, 2
     assert !@dg.has_edge?(1, 2)
+    assert !@dg.has_out_edge?(1, 2)
+    assert !@dg.has_in_edge?(2, 1)
     @dg.remove_vertex 3
     assert !@dg.has_vertex?(3)
     assert !@dg.has_edge?(2, 3)
+    assert !@dg.has_out_edge?(2, 3)
+    assert !@dg.has_in_edge?(3, 2)
     assert_equal('(2-4)', @dg.edges.join)
   end
 

--- a/test/bidirectional_graph_test.rb
+++ b/test/bidirectional_graph_test.rb
@@ -1,12 +1,12 @@
 require 'test_helper'
 
-require 'rgl/adjacency'
-require 'rgl/bidirectional'
+require 'rgl/bidirectional_adjacency'
+require 'directed_graph_test'
 
 include RGL
 include RGL::Edge
 
-class TestBidirectionalGraph < Test::Unit::TestCase
+class TestBidirectionalAdjacencyGraph < TestDirectedGraph
   def setup
     @edges = [[1, 2], [1, 3], [2, 3], [2, 4], [2, 5], [2, 6], [3, 2], [3, 7], [3, 8],
              [5, 10], [6, 9], [7, 9], [7, 10], [8, 10]]
@@ -16,14 +16,14 @@ class TestBidirectionalGraph < Test::Unit::TestCase
       @out_neighbors[e[0]] << e[1]
       @in_neighbors[e[1]] << e[0]
     end
-    @dg = BidirectionalGraph.new
+    @dg = BidirectionalAdjacencyGraph.new
     @edges.each do |(src, target)|
       @dg.add_edge(src, target)
     end
   end
 
   def test_empty_graph
-    dg = BidirectionalGraph.new
+    dg = BidirectionalAdjacencyGraph.new
     assert dg.empty?
     assert dg.directed?
     assert(!dg.has_edge?(2, 1))
@@ -43,7 +43,7 @@ class TestBidirectionalGraph < Test::Unit::TestCase
   end
 
   def test_add
-    dg = BidirectionalGraph.new
+    dg = BidirectionalAdjacencyGraph.new
     dg.add_edge(1, 2)
     assert(!dg.empty?)
     assert(dg.has_edge?(1, 2))
@@ -110,7 +110,7 @@ class TestBidirectionalGraph < Test::Unit::TestCase
   end
 
   def test_add_vertices
-    dg = BidirectionalGraph.new
+    dg = BidirectionalAdjacencyGraph.new
     dg.add_vertices 1, 3, 2, 4
     assert_equal dg.vertices.sort, [1, 2, 3, 4]
 
@@ -119,7 +119,7 @@ class TestBidirectionalGraph < Test::Unit::TestCase
   end
 
   def test_creating_from_array
-    dg = BidirectionalGraph[1, 2, 3, 4]
+    dg = BidirectionalAdjacencyGraph[1, 2, 3, 4]
     assert_equal([1, 2, 3, 4], dg.vertices.sort)
     assert_equal('(1-2)(3-4)', dg.edges.join)
   end

--- a/test/bidirectional_graph_test.rb
+++ b/test/bidirectional_graph_test.rb
@@ -8,8 +8,10 @@ include RGL::Edge
 
 class TestBidirectionalGraph < Test::Unit::TestCase
   def setup
+    @edges = [[1, 2], [1, 3], [2, 3], [2, 4], [2, 5], [2, 6], [3, 2], [3, 7], [3, 8],
+             [5, 10], [6, 9], [7, 9], [7, 10], [8, 10]]
     @dg = BidirectionalGraph.new
-    [[1, 2], [2, 3], [3, 2], [2, 4]].each do |(src, target)|
+    @edges.each do |(src, target)|
       @dg.add_edge(src, target)
     end
   end
@@ -65,42 +67,23 @@ class TestBidirectionalGraph < Test::Unit::TestCase
   end
 
   def test_edges
-    assert_equal(4, @dg.edges.length)
-    assert_equal([1, 2, 2, 3], @dg.edges.map { |l| l.source }.sort)
-    assert_equal([2, 2, 3, 4], @dg.edges.map { |l| l.target }.sort)
-    assert_equal("(1-2)(2-3)(2-4)(3-2)", @dg.edges.map { |l| l.to_s }.sort.join)
+    assert_equal(14, @dg.edges.length)
+    assert_equal(@edges.map { |e| e[0] }.to_set, @dg.edges.map { |l| l.source }.to_set)
+    assert_equal(@edges.map { |e| e[1] }.to_set, @dg.edges.map { |l| l.target }.to_set)
+    assert_equal("(1-2)(1-3)(2-3)(2-4)(2-5)(2-6)(3-2)(3-7)(3-8)(5-10)(6-9)(7-10)(7-9)(8-10)", @dg.edges.map { |l| l.to_s }.sort.join)
     #    assert_equal([0,1,2,3], @dg.edges.map {|l| l.info}.sort)
   end
 
   def test_vertices
-    assert_equal([1, 2, 3, 4], @dg.vertices.sort)
+    assert_equal(@edges.flatten.to_set, @dg.vertices.to_set)
   end
 
   def test_edges_from_to?
-    assert @dg.has_edge?(1, 2)
-    assert @dg.has_out_edge?(1, 2)
-    assert @dg.has_in_edge?(2, 1)
-    assert @dg.has_edge?(2, 3)
-    assert @dg.has_out_edge?(2, 3)
-    assert @dg.has_in_edge?(3, 2)
-    assert @dg.has_edge?(3, 2)
-    assert @dg.has_out_edge?(3, 2)
-    assert @dg.has_in_edge?(2, 3)
-    assert @dg.has_edge?(2, 4)
-    assert @dg.has_out_edge?(2, 4)
-    assert @dg.has_in_edge?(4, 2)
-    assert !@dg.has_edge?(2, 1)
-    assert !@dg.has_out_edge?(2, 1)
-    assert !@dg.has_in_edge?(1, 2)
-    assert !@dg.has_edge?(3, 1)
-    assert !@dg.has_out_edge?(3, 1)
-    assert !@dg.has_in_edge?(1, 3)
-    assert !@dg.has_edge?(4, 1)
-    assert !@dg.has_out_edge?(4, 1)
-    assert !@dg.has_in_edge?(1, 4)
-    assert !@dg.has_edge?(4, 2)
-    assert !@dg.has_out_edge?(4, 2)
-    assert !@dg.has_in_edge?(2, 4)
+    @edges.each do |u, v|
+      assert @dg.has_edge?(u, v)
+      assert @dg.has_out_edge?(u, v)
+      assert @dg.has_in_edge?(v, u)
+    end
   end
 
   def test_remove_edges
@@ -117,7 +100,7 @@ class TestBidirectionalGraph < Test::Unit::TestCase
     assert !@dg.has_edge?(2, 3)
     assert !@dg.has_out_edge?(2, 3)
     assert !@dg.has_in_edge?(3, 2)
-    assert_equal('(2-4)', @dg.edges.join)
+    assert_equal('(2-4)(2-5)(2-6)(5-10)(6-9)(7-9)(7-10)(8-10)', @dg.edges.join)
   end
 
   def test_add_vertices
@@ -149,6 +132,6 @@ class TestBidirectionalGraph < Test::Unit::TestCase
 
   def test_to_undirected
     undirected = @dg.to_undirected
-    assert_equal '(1=2)(2=3)(2=4)', undirected.edges.sort.join
+    assert_equal '(1=2)(1=3)(2=3)(2=4)(2=5)(2=6)(3=7)(3=8)(5=10)(6=9)(7=9)(7=10)(8=10)', undirected.edges.sort.join
   end
 end

--- a/test/bidirectional_graph_test.rb
+++ b/test/bidirectional_graph_test.rb
@@ -1,12 +1,11 @@
 require 'test_helper'
 
 require 'rgl/bidirectional_adjacency'
-require 'directed_graph_test'
 
 include RGL
 include RGL::Edge
 
-class TestBidirectionalAdjacencyGraph < TestDirectedGraph
+class TestBidirectionalAdjacencyGraph < Test::Unit::TestCase
   def setup
     @edges = [[1, 2], [1, 3], [2, 3], [2, 4], [2, 5], [2, 6], [3, 2], [3, 7], [3, 8],
              [5, 10], [6, 9], [7, 9], [7, 10], [8, 10]]

--- a/test/directed_graph_test.rb
+++ b/test/directed_graph_test.rb
@@ -101,12 +101,20 @@ class TestDirectedGraph < Test::Unit::TestCase
     assert_equal('(1-2)(3-4)', dg.edges.join)
   end
 
-  def test_reverse
-    # Add isolated vertex
-    @dg.add_vertex(42)
-    reverted = @dg.reverse
+  def test_creating_from_graphs
+    dg = @dg.clone
+    @gfa.each_edge { |e| dg.add_edge(e[0], e[1])}
+    dg2 = DirectedAdjacencyGraph.new(Set, @dg, @gfa)
+    assert_equal(dg2, dg2)
+  end
 
-    @dg.each_edge do |u, v|
+  def test_reverse
+    dg = @dg.clone
+    # Add isolated vertex
+    dg.add_vertex(42)
+    reverted = dg.reverse
+
+    dg.each_edge do |u, v|
       assert(reverted.has_edge?(v, u))
     end
 

--- a/test/directed_graph_test.rb
+++ b/test/directed_graph_test.rb
@@ -11,10 +11,12 @@ class TestDirectedGraph < Test::Unit::TestCase
     [[1, 2], [2, 3], [3, 2], [2, 4]].each do |(src, target)|
       @dg.add_edge(src, target)
     end
+    @eg = DirectedAdjacencyGraph.new
+    @gfa = DirectedAdjacencyGraph[1, 2, 3, 4]
   end
 
   def test_empty_graph
-    dg = DirectedAdjacencyGraph.new
+    dg = @eg.clone
     assert dg.empty?
     assert dg.directed?
     assert(!dg.has_edge?(2, 1))
@@ -31,7 +33,7 @@ class TestDirectedGraph < Test::Unit::TestCase
   end
 
   def test_add
-    dg = DirectedAdjacencyGraph.new
+    dg = @eg.clone
     dg.add_edge(1, 2)
     assert(!dg.empty?)
     assert(dg.has_edge?(1, 2))
@@ -85,7 +87,7 @@ class TestDirectedGraph < Test::Unit::TestCase
   end
 
   def test_add_vertices
-    dg = DirectedAdjacencyGraph.new
+    dg = @eg.clone
     dg.add_vertices 1, 3, 2, 4
     assert_equal dg.vertices.sort, [1, 2, 3, 4]
 
@@ -94,7 +96,7 @@ class TestDirectedGraph < Test::Unit::TestCase
   end
 
   def test_creating_from_array
-    dg = DirectedAdjacencyGraph[1, 2, 3, 4]
+    dg = @gfa.clone
     assert_equal([1, 2, 3, 4], dg.vertices.sort)
     assert_equal('(1-2)(3-4)', dg.edges.join)
   end


### PR DESCRIPTION
If you're comfortable with a separate `vertices_dict` for in-edges, I think this approach is cleaner. A `DirectedAdjacencyGraph` has hardly any state other than the `vertices_dict`, so why not simply make a separate graph? This avoids having to copy _any_ implementation from the base class; it is implemented using only methods exposed by `DirectedAdjacencyGraph`.

This was my original proposed approach.

The only downside that I can see is that it duplicates the vertex references used as keys in the two `vertices_dict`s and duplicates operations on them. As you noted a couple of days ago, however, it is impossible to eliminate that without pulling some implementation into the subclass.

I restored the original module and made the changes to the test you suggested.