### PR TITLE
Fix example for style settings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ graph_options = {
     "label"    => "Graph\n (generated #{Time.now.utc})"
 }
 
-dot = graph.to_dot_graph(graph_options).to_s
+graph.write_to_graphic_file('png', 'graph', graph_options)
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -243,29 +243,22 @@ The available options are described in the [GraphViz DOT Spec](https://www.graph
 require 'rgl/adjacency'
 require 'rgl/dot'
 
-graph = RGL::DirectedAdjacencyGraph['a','b', 'c','d']
+graph = RGL::DirectedAdjacencyGraph['a','b', 'c','d', 'a','c']
 
-graph.add_edge('a', 'c')
-
-# Vertex Settings
 graph.set_vertex_options('a', label: 'This is A', shape: 'box3d', fontcolor: 'green', fontsize: 16)
 graph.set_vertex_options('b', label: 'This is B', shape: 'tab', fontcolor: 'red', fontsize: 14)
 graph.set_vertex_options('c', shape: 'tab', fontcolor: 'blue')
 
-# Edge Settings
 graph.set_edge_options('a', 'b', label: 'NotCapitalEdge', style: 'dotted', direction: 'back', color: 'magenta')
 graph.set_edge_options('a', 'c', weight: 5, color: 'blue')
 
-# This hash contains the configuration for the overall graph
-# Applicable values are listed in lib/rgl/rdot.rb GRAPH_OPTS
-# The values for edge and vertex will make use of the hashes above
 graph_options = {
     "rankdir"  => "LR",
     "labelloc" => "t",
     "label"    => "Graph\n (generated #{Time.now.utc})"
 }
 
-graph.write_to_graphic_file('png', 'graph', graph_options)
+dot = graph.to_dot_graph(graph_options).to_s
 
 ```
 


### PR DESCRIPTION
I noticed that the README still had the old test example.