### PR TITLE
docs: fix outdated links, typos, and missing community files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,8 +6,9 @@ started.
 
 ## Code of Conduct
 
-Please note that this project is released with a Contributor Code of Conduct. By
-participating in this project you agree to abide by its terms.
+Please note that this project is released with a
+[Contributor Code of Conduct](../CODE_OF_CONDUCT.md). By participating in this
+project you agree to abide by its terms.
 
 ## Development Setup
 
@@ -110,4 +111,4 @@ information on using pull requests.
 ## License
 
 By contributing, you agree that your contributions will be licensed under the
-{file:../LICENSE}.
+[LICENSE](../LICENSE).

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,7 +1,0 @@
-FROM gitpod/workspace-full
-
-# Install graphviz
-RUN sudo apt-get update --fix-missing \
-    && sudo apt-get install -y graphviz
-
-USER gitpod

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,0 @@
-image:
-  file: .gitpod.Dockerfile
-tasks:
-  - init: bundle install

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socioeconomic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+monora@gmail.com. All complaints will be reviewed and investigated promptly
+and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Ruby Graph Library (RGL)
 [![Test](https://github.com/monora/rgl/actions/workflows/test.yml/badge.svg)](https://github.com/monora/rgl/actions/workflows/test.yml) [![Doc](https://github.com/monora/rgl/actions/workflows/doc.yml/badge.svg)](https://github.com/monora/rgl/actions/workflows/doc.yml)
 [![Version](https://badge.fury.io/rb/rgl.svg)](https://badge.fury.io/rb/rgl)
-[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/monora/rgl)
 RGL is a framework for graph data structures and algorithms.
 
 The design of the library is much influenced by the Boost Graph Library (BGL)
@@ -276,14 +275,14 @@ Library](https://www.boost.org/libs/graph/doc) kindly allowed to use the BGL
 documentation as a *cheap* reference for RGL. He and Robert also gave feedback
 and many ideas for RGL.
 
-Dave Thomas for [RDoc](https://rdoc.sourceforge.net) which generated what you
+Dave Thomas for [RDoc](https://ruby.github.io/rdoc/) which generated what you
 read and matz for Ruby. Dave included in the latest version of RDoc (alpha9)
 the module {RGL::DOT} which is used instead of Roberts module to visualize
 graphs.
 
 Jeremy Bopp, John Carter, Sascha Doerdelmann, Shawn Garbett, Andreas Schörk, Dan
 Čermák, Kirill Lashuk and Markus Napp for contributing additions, test cases and
-bugfixes. The complete list of contributers is
+bugfixes. The complete list of contributors is
 [here](https://github.com/monora/rgl/contributors).
 
 ## Links
@@ -295,6 +294,6 @@ bugfixes. The complete list of contributers is
 
 ## Copying
 
-RGL is Copyright (c) 2002,2004,2005,2008,2013,2015,2019,2020,2022,2023 by Horst
+RGL is Copyright (c) 2002,2004,2005,2008,2013,2015,2019,2020,2022,2023,2024,2025,2026 by Horst
 Duchene. It is free software, and may be redistributed under the {file:LICENSE}
 and terms specified in the LICENSE file.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities by email to monora@gmail.com rather than
+opening a public GitHub issue.
+
+You will receive a response within a reasonable time. If the issue is confirmed,
+a fix will be released as soon as possible.


### PR DESCRIPTION
## Summary

- Fix typo: "contributers" → "contributors" in README.md
- Update dead `rdoc.sourceforge.net` link to `ruby.github.io/rdoc/`
- Extend copyright years to 2024–2026
- Remove Gitpod badge and config files (`.gitpod.yml`, `.gitpod.Dockerfile`)
- Fix YARD syntax `{file:../LICENSE}` → Markdown link in CONTRIBUTING.md
- Add link to `CODE_OF_CONDUCT.md` in CONTRIBUTING.md
- Add `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)
- Add `SECURITY.md` with vulnerability reporting instructions

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)