### PR TITLE
chore: Ruby code modernization

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -61,7 +61,7 @@ end
 def count_lines(filename)
   lines = 0
   codelines = 0
-  open(filename) { |f|
+  File.open(filename) { |f|
     f.each do |line|
       lines += 1
       next if line =~ /^\s*$/

--- a/lib/rgl/adjacency.rb
+++ b/lib/rgl/adjacency.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # adjacency.rb
 #
 require 'rgl/mutable'
@@ -77,7 +79,7 @@ module RGL
     #
     # @see Graph#has_vertex
     def has_vertex?(v)
-      @vertices_dict.has_key?(v)
+      @vertices_dict.key?(v)
     end
 
     # Complexity is O(1), if a Set is used as adjacency list. Otherwise,

--- a/lib/rgl/base.rb
+++ b/lib/rgl/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # base.rb
 
 # Module {RGL} defines the namespace for all modules and classes of the graph
@@ -316,7 +318,7 @@ module RGL
         each_adjacent(u) do |v|
           edge = UnDirectedEdge.new(u, v)
 
-          unless visited.has_key?(edge)
+          unless visited.key?(edge)
             visited[edge] = true
             yield u, v
           end

--- a/lib/rgl/bellman_ford.rb
+++ b/lib/rgl/bellman_ford.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rgl/dijkstra_visitor'
 require 'rgl/edge_properties_map'
 require 'rgl/path_builder'
@@ -19,7 +21,7 @@ module RGL
     def initialize(graph)
       super(graph)
 
-      # by default, through an exception if a negative-weight cycle is detected
+      # by default, raise an exception if a negative-weight cycle is detected
       @edge_not_minimized_event_handler = lambda do |u, v|
         raise ArgumentError.new("there is a negative-weight cycle including edge (#{u}, #{v})")
       end

--- a/lib/rgl/bidirectional.rb
+++ b/lib/rgl/bidirectional.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rgl/base'
 
 module RGL
@@ -23,7 +25,6 @@ module RGL
     #
     def each_in_neighbor(v)
       raise NotImplementedError
-      yield u
     end
 
     alias :each_out_neighbor :each_adjacent

--- a/lib/rgl/bidirectional_adjacency.rb
+++ b/lib/rgl/bidirectional_adjacency.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # bidirectional_adjacency.rb
 #
 require 'rgl/adjacency'

--- a/lib/rgl/bipartite.rb
+++ b/lib/rgl/bipartite.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rgl/base'
 require 'rgl/traversal'
 

--- a/lib/rgl/condensation.rb
+++ b/lib/rgl/condensation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rgl/base'
 require 'rgl/connected_components'
 require 'rgl/implicit'

--- a/lib/rgl/connected_components.rb
+++ b/lib/rgl/connected_components.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # connected_components.rb
 #
 # This file contains the algorithms for the connected components of an

--- a/lib/rgl/dijkstra.rb
+++ b/lib/rgl/dijkstra.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rgl/dijkstra_visitor'
 require 'rgl/edge_properties_map'
 require 'rgl/path_builder'

--- a/lib/rgl/dijkstra_visitor.rb
+++ b/lib/rgl/dijkstra_visitor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rgl/base'
 require 'rgl/graph_visitor'
 

--- a/lib/rgl/dot.rb
+++ b/lib/rgl/dot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # dot.rb
 #
 # Minimal Dot support, based on Dave Thomas's dot module (included in rdoc).

--- a/lib/rgl/edge_properties_map.rb
+++ b/lib/rgl/edge_properties_map.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RGL
 
   class EdgePropertiesMap

--- a/lib/rgl/edmonds_karp.rb
+++ b/lib/rgl/edmonds_karp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rgl/edge_properties_map'
 require 'rgl/traversal'
 

--- a/lib/rgl/graph_iterator.rb
+++ b/lib/rgl/graph_iterator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stream'
 
 require 'rgl/graph_wrapper'

--- a/lib/rgl/graph_visitor.rb
+++ b/lib/rgl/graph_visitor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rgl/graph_wrapper'
 
 module RGL

--- a/lib/rgl/graph_wrapper.rb
+++ b/lib/rgl/graph_wrapper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RGL
 
   module GraphWrapper

--- a/lib/rgl/graphxml.rb
+++ b/lib/rgl/graphxml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # graphxml.rb
 #
 # This file contains minimal support for creating RGL graphs from the GraphML

--- a/lib/rgl/implicit.rb
+++ b/lib/rgl/implicit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # implicit.rb
 #
 # This file contains the definition of the class RGL::ImplicitGraph, which

--- a/lib/rgl/mutable.rb
+++ b/lib/rgl/mutable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # mutable.rb
 
 require 'rgl/base'

--- a/lib/rgl/path_builder.rb
+++ b/lib/rgl/path_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RGL
 
   class PathBuilder
@@ -9,7 +11,7 @@ module RGL
     end
 
     def path(target)
-      if @paths.has_key?(target)
+      if @paths.key?(target)
         @paths[target]
       else
         @paths[target] = restore_path(target)

--- a/lib/rgl/prim.rb
+++ b/lib/rgl/prim.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rgl/dijkstra'
 require 'rgl/adjacency'
 

--- a/lib/rgl/rdot.rb
+++ b/lib/rgl/rdot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RGL
 
   # This is a modified version of +dot.rb+ from {https://ruby.github.io/rdoc Dave

--- a/lib/rgl/topsort.rb
+++ b/lib/rgl/topsort.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # topsort.rb
 
 require 'rgl/graph_iterator'
@@ -26,16 +28,16 @@ module RGL
 
     def set_to_begin
       @waiting   = Array.new
-      @inDegrees = Hash.new(0)
+      @in_degrees = Hash.new(0)
 
       graph.each_vertex do |u|
-        @inDegrees[u] = 0 unless @inDegrees.has_key?(u)
+        @in_degrees[u] = 0 unless @in_degrees.key?(u)
         graph.each_adjacent(u) do |v|
-          @inDegrees[v] += 1
+          @in_degrees[v] += 1
         end
       end
 
-      @inDegrees.each_pair do |v, indegree|
+      @in_degrees.each_pair do |v, indegree|
         @waiting.push(v) if indegree.zero?
       end
     end
@@ -44,8 +46,8 @@ module RGL
     def basic_forward
       u = @waiting.pop
       graph.each_adjacent(u) do |v|
-        @inDegrees[v] -= 1
-        @waiting.push(v) if @inDegrees[v].zero?
+        @in_degrees[v] -= 1
+        @waiting.push(v) if @in_degrees[v].zero?
       end
       u
     end

--- a/lib/rgl/transitiv_closure.rb
+++ b/lib/rgl/transitiv_closure.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # This file is deprecated and only provided for backward compatibility.
 require 'rgl/transitivity'

--- a/lib/rgl/transitivity.rb
+++ b/lib/rgl/transitivity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rgl/base'
 require 'rgl/adjacency'
 require 'rgl/condensation'

--- a/lib/rgl/traversal.rb
+++ b/lib/rgl/traversal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # traversal.rb
 #
 require 'rgl/base'

--- a/lib/rgl/version.rb
+++ b/lib/rgl/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RGL
   VERSION = "0.6.6".freeze
 end


### PR DESCRIPTION
## Summary

- Add `# frozen_string_literal: true` to all 27 `lib/rgl/*.rb` files (only `path.rb` had it)
- Replace deprecated `has_key?` with `key?` in `adjacency.rb`, `base.rb`, `path_builder.rb`, `topsort.rb`
- Rename `@inDegrees` to `@in_degrees` in `topsort.rb` (Ruby snake_case convention)
- Remove unreachable `yield u` after `raise NotImplementedError` in `bidirectional.rb`
- Replace deprecated `Kernel#open` with `File.open` in `Rakefile` (removed in Ruby 3.3)
- Fix typo in `bellman_ford.rb`: "through an exception" → "raise an exception"

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)